### PR TITLE
feat(docker): Rewrite Docker build script

### DIFF
--- a/build-docker-images.sh
+++ b/build-docker-images.sh
@@ -4,28 +4,39 @@ set -u
 # collect params from ENV vars
 DATE=`date +%Y-%m-%d`
 DOCKER_REPOSITORY="pelias"
-DOCKER_PROJECT="${DOCKER_REPOSITORY}/${CIRCLE_PROJECT_REPONAME}"
+PROJECT_NAME=$CIRCLE_PROJECT_REPONAME
+REVISION=$CIRCLE_SHA1
 
+# allow docker-specific projects to be prefixed with docker in GitHub
+PROJECT_NAME=${PROJECT_NAME##docker-}
+
+# construct project name
+DOCKER_PROJECT="$DOCKER_REPOSITORY/$PROJECT_NAME"
+
+# construct valid branch name
 BRANCH="$(echo $CIRCLE_BRANCH | tr '/' '-')" #slashes are not valid in docker tags. replace with dashes
 
-# the name of the image that represents the "branch", that is an image that will be updated over time with the git branch
-# the production branch is changed to "latest", otherwise the git branch becomes the name of the version
-if [[ "${BRANCH}" == "production" ]]; then
-	DOCKER_BRANCH_IMAGE_VERSION="latest"
-else
-	DOCKER_BRANCH_IMAGE_VERSION="$BRANCH"
-fi
-DOCKER_BRANCH_IMAGE_NAME="${DOCKER_PROJECT}:${DOCKER_BRANCH_IMAGE_VERSION}"
+# list of tags to build and push
+tags=(
+"$DOCKER_PROJECT:$BRANCH"
+"$DOCKER_PROJECT:$BRANCH-$DATE-$REVISION"
+)
 
-# the name of the image that represents the "tag", that is an image that is named with the date and git commit and will never be changed
-DOCKER_TAG_IMAGE_VERSION="${BRANCH}-${DATE}-${CIRCLE_SHA1}"
-DOCKER_TAG_IMAGE_NAME="${DOCKER_PROJECT}:${DOCKER_TAG_IMAGE_VERSION}"
+# additionally, push to latest tag on master branch
+if [[ "$BRANCH" == "master" ]]; then
+  tags+=("$DOCKER_PROJECT:latest")
+fi
 
 # build branch image and login to docker hub
-docker build -t $DOCKER_BRANCH_IMAGE_NAME .
+docker build -t ${tags[0]} .
 docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
 
 # copy the image to the commit tag and push
-docker tag $DOCKER_BRANCH_IMAGE_NAME $DOCKER_TAG_IMAGE_NAME
-docker push $DOCKER_BRANCH_IMAGE_NAME
-docker push $DOCKER_TAG_IMAGE_NAME
+for tag in ${tags[@]}; do
+  # all tags except the first one (which was used when building)
+  # must be associated with the result of docker build
+  if [[ "$tag" != "${tags[0]}" ]]; then
+    docker tag ${tags[0]} $tag
+  fi
+  docker push $tag
+done


### PR DESCRIPTION
This is a near complete rewrite of the Docker build script that is in the process of being adopted across all of our CircleCI builds.

It includes the following changes:
- Moves building of the `latest` tag from `production` to `master` branch
- Improve the management of the different tags we push to docker. It now uses an array and so could in theory be extended however we wanted
- Remove the prefix `docker-` from any GitHub repositories when constructing the Docker image name. I intend to use this to move, for example `pelias/baseimage` to `pelias/docker-baseimage`

Connects https://github.com/pelias/pelias/issues/749