### PR TITLE
add --no-cache to docker build command

### DIFF
--- a/build-docker-images.sh
+++ b/build-docker-images.sh
@@ -29,7 +29,7 @@ if [[ "$BRANCH" == "master" ]]; then
 fi
 
 # build branch image and login to docker hub
-docker build -t ${tags[0]} .
+docker build --no-cache -t ${tags[0]} .
 docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
 
 # copy the image to the commit tag and push


### PR DESCRIPTION
Not sure if this is required 🤷 as you'd expect each CI run to have a clean cache.
I was trying to debug why a build didn't update as expected today, could, maybe, possibly, be due to this.