### PR TITLE
Support building on Github Actions or CircleCI

### DIFF
--- a/build-docker-images.sh
+++ b/build-docker-images.sh
@@ -1,21 +1,25 @@
 #!/bin/bash
-set -u
+set -ux
 
-# collect params from ENV vars
+# calculate basic values
 DATE=`date +%Y-%m-%d`
-DOCKER_REPOSITORY="pelias"
-PROJECT_NAME=$CIRCLE_PROJECT_REPONAME
-REVISION=$CIRCLE_SHA1
+REVISION="$(git rev-parse HEAD)"
 
-# allow docker-specific projects to be prefixed with docker in GitHub
-PROJECT_NAME=${PROJECT_NAME##docker-}
+# calculate the full repository name (org and repo name) on Circle if defined
+CIRCLE_REPOSITORY="${CIRCLE_PROJECT_USERNAME:-}/${CIRCLE_PROJECT_REPONAME:-}"
+# get the repository name (e.g. pelias/api) from either CircleCI or Github
+DOCKER_PROJECT="${GITHUB_REPOSITORY:-$CIRCLE_REPOSITORY}"
 
-# construct project name
-DOCKER_PROJECT="$DOCKER_REPOSITORY/$PROJECT_NAME"
+# construct project name, removing `docker-` prefix if present
+# this means a Github repository like pelias/docker-libpostal-baseimage will
+# end up pushing to the pelias/libpostal-baseimage docker tag
+DOCKER_PROJECT="${DOCKER_PROJECT/\/docker-/\/}"
 
-# construct valid branch name
+# construct a "branch" name valid on Docker
 invalid_chars="/@" # list of characters not valid in a docker tag
-BRANCH="$(echo $CIRCLE_BRANCH | tr "$invalid_chars" '-')"
+RAW_BRANCH="${GITHUB_REF:-$CIRCLE_BRANCH}" # get the branch from either Github or Circle
+# take the actual branch name and replace invalid characters with dashes
+BRANCH="$(echo $RAW_BRANCH | cut -d'/' -f 3 | tr "$invalid_chars" '-')"
 
 # list of tags to build and push
 tags=(


### PR DESCRIPTION
We recently moved the Pelias project away from TravisCI, and are now running our unit tests on Github Actions.

Docker image builds, though, are still run on CircleCI. It might be nice to move everything to a single CI provider, so this PR allows the Docker image build script to work on _either_ CircleCI or Github Actions.