### PR TITLE
Simplify Docker build

### DIFF
--- a/build-docker-images.sh
+++ b/build-docker-images.sh
@@ -32,9 +32,11 @@ if [[ "$BRANCH" == "master" ]]; then
   tags+=("$DOCKER_PROJECT:latest")
 fi
 
-# build branch image and login to docker hub
-docker build -t ${tags[0]} .
+# log in to Docker Hub _before_ building to avoid rate limits
 docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+
+# build the docker image
+docker build -t ${tags[0]} .
 
 # copy the image to the commit tag and push
 for tag in ${tags[@]}; do

--- a/build-docker-images.sh
+++ b/build-docker-images.sh
@@ -35,15 +35,8 @@ fi
 # log in to Docker Hub _before_ building to avoid rate limits
 docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
 
-# build the docker image
-docker build -t ${tags[0]} .
-
-# copy the image to the commit tag and push
+# Build and push each tag (the built image will be reused after the first build)
 for tag in ${tags[@]}; do
-  # all tags except the first one (which was used when building)
-  # must be associated with the result of docker build
-  if [[ "$tag" != "${tags[0]}" ]]; then
-    docker tag ${tags[0]} $tag
-  fi
+  docker build -t $tag .
   docker push $tag
 done


### PR DESCRIPTION
The original code here to manage the process of building our Docker images is pretty old. It's some of the first Docker-related code we ever wrote for Pelias.

In the ~4 years since then, we've learned a lot, and Docker has changed. This PR implements two simplifications/fixes to the build process:
- Log in to Docker Hub _before_ building, to avoid any chance that the [Docker download rate limits](https://docs.docker.com/docker-hub/download-rate-limit/) will cause fetching the baseimage to fail
- Simplify the code that creates all the various tags we end up pushing. We previously went through pains to run `docker build` only once, when in reality its fine to do it several times, as the Docker cache will make it a no-op in subsequent runs