### PR TITLE
fix: add support for branches with `/`

### DIFF
--- a/build-docker-images.sh
+++ b/build-docker-images.sh
@@ -27,7 +27,7 @@ DOCKER_PROJECT="${DOCKER_PROJECT/\/docker-/\/}"
 invalid_chars="/@" # list of characters not valid in a docker tag
 RAW_BRANCH="${GITHUB_REF:-$CIRCLE_BRANCH}" # get the branch from either Github or Circle
 # take the actual branch name and replace invalid characters with dashes
-BRANCH="$(echo $RAW_BRANCH | cut -d'/' -f 3 | tr "$invalid_chars" '-')"
+BRANCH="$(echo $RAW_BRANCH | cut -d'/' -f 3- | tr "$invalid_chars" '-')"
 
 # list of tags to build and push
 tags=(


### PR DESCRIPTION
Hi there,

When I was working on https://github.com/pelias/spatial/pull/76 using the branch name `joxit/ci/github-actions`, the CI created an image named [`pelias/spatial:joxit`](https://hub.docker.com/layers/spatial/pelias/spatial/joxit/images/sha256-adcb67e3b77c4f605e0187779f8ecc500da9816c6d5d42da1a65d5696e854d62?context=explore) instead of `pelias/spatial:joxit-ci-github-actions` as before.

This is due to the use of `cut` when we are generating the BRANCH variable, we should take everything after the third slash.

**Before**
```sh
RAW_BRANCH="refs/heads/joxit/ci/github-actions"
BRANCH="$(echo $RAW_BRANCH | cut -d/ -f 3 | tr /@ -)"
echo $BRANCH # result is `joxit`
```

**After**
```sh
RAW_BRANCH="refs/heads/joxit/ci/github-actions"
BRANCH="$(echo $RAW_BRANCH | cut -d/ -f 3- | tr /@ -)"
echo $BRANCH # result is `joxit-ci-github-actions`
```