### PR TITLE
enable cross-platform docker image generation via docker buildx

### DIFF
--- a/build-docker-images.sh
+++ b/build-docker-images.sh
@@ -58,5 +58,10 @@ docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
 
 # Build and push each tag (the built image will be reused after the first build)
 for tag in ${tags[@]}; do
-  docker buildx build --push --platform="$DOCKER_BUILD_PLATFORMS" -t $tag .
+  if [ $DOCKER_BUILD_PLATFORMS == "classic" ]; then
+    docker build -t $tag .
+    docker push $tag
+  else
+    docker buildx build --push --platform="$DOCKER_BUILD_PLATFORMS" -t $tag .
+  fi
 done


### PR DESCRIPTION
As discussed in https://github.com/pelias/docker/issues/264 this PR:
- switches the default docker builds to use `docker buildx` instead of `docker build`
- changes our *default* build strategy to cross-compile `linux/amd64,linux/arm64,linux/arm/v7`
- allows the target platforms to be modified via the ENV var `DOCKER_BUILD_PLATFORMS`

ref: https://docs.docker.com/build/buildx/multiplatform-images/

cc @ddelange

replaces branch `buildx`: https://github.com/pelias/ci-tools/compare/master...buildx