### PR TITLE
updates for cross-platform builds

### DIFF
--- a/build-docker-images.sh
+++ b/build-docker-images.sh
@@ -50,7 +50,7 @@ if [[ "$BRANCH" == "master" ]]; then
 fi
 
 # default build targets can be configured with the DOCKER_BUILD_PLATFORMS env var
-DOCKER_BUILD_DEFAULT_PLATFORMS='linux/amd64,linux/arm64,linux/arm/v7'
+DOCKER_BUILD_DEFAULT_PLATFORMS='linux/amd64,linux/arm64'
 DOCKER_BUILD_PLATFORMS=${DOCKER_BUILD_PLATFORMS:-$DOCKER_BUILD_DEFAULT_PLATFORMS}
 
 # log in to Docker Hub _before_ building to avoid rate limits
@@ -58,10 +58,12 @@ docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
 
 # Build and push each tag (the built image will be reused after the first build)
 for tag in ${tags[@]}; do
-  if [ $DOCKER_BUILD_PLATFORMS == "classic" ]; then
+  if [ "$DOCKER_BUILD_PLATFORMS" == "classic" ]; then
     docker build -t $tag .
     docker push $tag
   else
+    docker buildx create --use --platform="$DOCKER_BUILD_PLATFORMS" --name 'multi-platform-builder'
+    docker buildx inspect --bootstrap
     docker buildx build --push --platform="$DOCKER_BUILD_PLATFORMS" -t $tag .
   fi
 done


### PR DESCRIPTION
when testing https://github.com/pelias/ci-tools/pull/11 I found a few issues:

- the `IF` statement doesn't seem to be correctly comparing the string 'classic' resulting in the `buildx` command being run by default, which was not inteded
- the default architectures supported by `elastic` are `amd64,arm64`, so I've dropped `linux/arm/v7` from our default architectures to avoid headaches there, I trust them to provide decent defaults.
- the `buildx` command has changed since this was PR originally drafted, requiring two additional steps.

https://github.com/pelias/docker/actions/runs/7045599952/job/19175661751
<img width="701" alt="Screenshot 2023-11-30 at 12 40 32" src="https://github.com/pelias/ci-tools/assets/738069/e8925893-7ee6-4bd9-b245-c4e0f1648d8b">
